### PR TITLE
Ignore config.xml files that have promotions in the file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.DS_Store
+.idea/*

--- a/signiant/destroy_artifacts.py
+++ b/signiant/destroy_artifacts.py
@@ -111,7 +111,8 @@ def __enumerate_remote_artifact_config_entries__(jobs_path):
                 print "Found config.xml at " + str(filenames)
             try:
                 #print root
-                yield parse_build_into_environment_variable_job_entry(root)
+                if not 'promotions' in root:
+                    yield parse_build_into_environment_variable_job_entry(root)
             except InvalidEntryError as e:
                 if VERBOSE:
                     print "Skipping over " + str(root)


### PR DESCRIPTION
When looking for config.xml files, ignore any that have 'promotions' in the file path